### PR TITLE
Nicer error when cwd is not playbook dir

### DIFF
--- a/arm/commands/freeze.py
+++ b/arm/commands/freeze.py
@@ -1,4 +1,4 @@
-import os, shutil, sys
+import os, shutil, sys, textwrap
 from . import Command
 from arm.util import get_playbook_root
 import argparse
@@ -16,6 +16,11 @@ class freeze(Command):
     def run(self, argv):
         
         _root = get_playbook_root(os.getcwd())
+        if not _root:
+            print(textwrap.dedent('''\
+            can't find playbook. 
+            use `arm init` to create recommended structure.'''))
+            return 1
         _roles_directory = os.path.join(_root, 'roles')
         for _item in os.listdir(_roles_directory):
             _item = os.path.join(_roles_directory, _item)


### PR DESCRIPTION
Instead of:

    $ arm freeze
    Traceback (most recent call last):
      File "/Users/marca/python/virtualenvs/smstack/bin/arm", line 6, in <module>
        exec(compile(open(__file__).read(), __file__, 'exec'))
      File "/Users/marca/dev/git-repos/ansible-role-manager/bin/arm", line 5, in <module>
        main()
      File "/Users/marca/dev/git-repos/ansible-role-manager/arm/main.py", line 48, in main
        args.func(args)
      File "/Users/marca/dev/git-repos/ansible-role-manager/arm/commands/freeze.py", line 19, in run
        _roles_directory = os.path.join(_root, 'roles')
      File "/Users/marca/python/virtualenvs/smstack/bin/../lib/python2.7/posixpath.py", line 77, in join
        elif path == '' or path.endswith('/'):
    AttributeError: 'bool' object has no attribute 'endswith'

we get:

    $ arm freeze
    can't find playbook.
    use `arm init` to create recommended structure.